### PR TITLE
Updated the protobuf loading code to latest format.

### DIFF
--- a/protobuftracereader.cpp
+++ b/protobuftracereader.cpp
@@ -1,7 +1,11 @@
 #include "protobuftracereader.h"
+#include "templight_messages.pb.h"
+
 #include <fstream>
 #include "make_unique.hpp"
 #include <QFileInfo>
+
+#include <vector>
 
 namespace Templar {
 
@@ -22,7 +26,7 @@ void ProtobufTraceReader::buildFromTrace(TemplightTrace const &trace,
     for (int entryIndex = 0; entryIndex < trace.entries_size(); ++entryIndex) {
         auto &entry = trace.entries(entryIndex);
         if (entry.has_begin()) {
-            begin(entry.begin(), model);
+            begin(entry.begin(), trace, model);
         } else if (entry.has_end()) {
             end(entry.end());
         }
@@ -40,13 +44,48 @@ TraceEntry::InstantiationKind
 instantiationKindFromFile(::TemplightEntry_InstantiationKind kindInFile) {
     return static_cast<TraceEntry::InstantiationKind>(int(kindInFile));
 }
+
+struct dict_expansion_task {
+  DictionaryEntry const * p_entry;
+  std::size_t char_id;
+  std::size_t mark_id;
+};
 }
 
 void ProtobufTraceReader::begin(TemplightEntry_Begin const &begin,
+                                TemplightTrace const &trace,
                                 UsedSourceFileModel &model) {
     traceEntryPtr entry(new TraceEntry());
     entry->kind = instantiationKindFromFile(begin.kind());
-    entry->context = begin.name().name().c_str();
+    
+    if (begin.name().has_name()) {
+        entry->context = begin.name().name().c_str();
+    } else if (begin.name().has_dict_id()) {
+        // TODO Build a template-name dictionary that does the string expansion on-demand (and maybe produce reduced expansion levels)
+        std::string expanded_name;
+        std::vector< dict_expansion_task > tasks;
+        tasks.push_back(dict_expansion_task{&trace.names(begin.name().dict_id()), 0, 0});
+        while( !tasks.empty() ) {
+            const std::string& dict_name = tasks.back().p_entry->marked_name();
+            std::size_t new_char_id = 
+              std::find(dict_name.begin() + tasks.back().char_id, 
+                        dict_name.end(), '\0') - dict_name.begin();
+            expanded_name.append(dict_name.begin() + tasks.back().char_id, 
+                                 dict_name.begin() + new_char_id);
+            if( new_char_id < dict_name.size() ) {
+                tasks.back().char_id = new_char_id + 1;
+                dict_expansion_task next_task{&trace.names(tasks.back().p_entry->marker_ids(tasks.back().mark_id)), 0, 0};
+                tasks.back().mark_id += 1;
+                tasks.push_back(next_task);
+            } else {
+                tasks.pop_back();
+            }
+        }
+        entry->context = expanded_name.c_str();
+    } else {
+      // TODO Should report this as an error (unsupported format).
+    }
+    
     if (begin.location().has_file_name()) {
         QFileInfo fileInfo(begin.location().file_name().c_str());
         model.Add(fileInfo.isRelative() ? fileInfo.filePath()

--- a/protobuftracereader.h
+++ b/protobuftracereader.h
@@ -2,7 +2,11 @@
 #define PROTOBUFTRACEREADER_H_
 
 #include "tracereader.h"
-#include "templight_messages.pb.h"
+
+// forward-declare the protoc-generated classes:
+class TemplightTrace;
+class TemplightEntry_Begin;
+class TemplightEntry_End;
 
 namespace Templar {
 
@@ -14,7 +18,7 @@ struct ProtobufTraceReader : TraceReader {
   private:
     void buildFromTrace(TemplightTrace const &trace,
                         UsedSourceFileModel &model);
-    void begin(TemplightEntry_Begin const &, UsedSourceFileModel &model);
+    void begin(TemplightEntry_Begin const &, TemplightTrace const &, UsedSourceFileModel &);
     void end(TemplightEntry_End const &);
 };
 

--- a/templight_messages.proto
+++ b/templight_messages.proto
@@ -23,6 +23,7 @@ message TemplightEntry {
 //     }
     optional string name = 1;
     optional bytes compressed_name = 2;
+    optional uint32 dict_id = 3;
   }
   
   message SourceLocation {
@@ -53,9 +54,15 @@ message TemplightEntry {
   optional End end = 2;
 }
 
+message DictionaryEntry {
+  required string marked_name = 1;
+  repeated uint32 marker_ids = 2;
+}
+
 message TemplightTrace {
   required TemplightHeader header = 1;
   repeated TemplightEntry entries = 2;
+  repeated DictionaryEntry names = 3;
 }
 
 message TemplightTraceCollection {


### PR DESCRIPTION
Updated the templight message definition file and added support for dictionary-compressed template names from the protobuf files.

The code that I added to load the dictionary-compressed template names is very rudimentary (just a full string substitution to form the original names). Ideally, as noted in the code, this could involve a smarter expansion scheme that could have a limited depth, which would both save time and memory (when loading) and could provide nicer names like something like "foo::bar<some<deep<template>>>" would be "foo::bar<..>" (at level 1), "foo::bar<some<..>>" (at level 2), and so on, which is what the protobuf format naturally does by replacing template parameters with placeholder characters and references to the dictionary entry of the names they stand for. I might work on some code to do this (because it's the kind of thing I would also need for the templight debugger, and I know that people also want this for metashell), so stay tuned.
